### PR TITLE
Fix unitsize in packet encoding for <32 channels

### DIFF
--- a/src/hardware/open-logic-bit/protocol.c
+++ b/src/hardware/open-logic-bit/protocol.c
@@ -636,7 +636,7 @@ SR_PRIV int openlb_receive_data(int fd, int revents, void *cb_data)
 	uint32_t *sample_buf = (uint32_t *)data;
 	for (uint32_t i=0; i<size/4; i++) {
 		uint16_t repeats = (devc->num_channels == 32) ? 1 : sample_buf[i] >> devc->num_channels;
-		uint32_t value   = sample_buf[i] >> 0;
+		uint32_t value   = sample_buf[i] & ((1 << devc->num_channels) - 1);
 
 		for (uint16_t j=0;j<repeats;j++)
 			openlb_push_sample(sdi, value, (j == (repeats -1)) && (i == ((size/4)-1)));

--- a/src/hardware/open-logic-bit/protocol.h
+++ b/src/hardware/open-logic-bit/protocol.h
@@ -45,7 +45,7 @@ struct dev_context {
 	uint32_t num_channels;
 
 	uint64_t num_samples;
-	uint32_t *data_buf;
+	void     *data_buf;
 	uint32_t data_pos;
 
 	uint16_t seq_num;
@@ -60,5 +60,6 @@ SR_PRIV int openlb_convert_triggers(const struct sr_dev_inst *sdi);
 SR_PRIV int openlb_close(struct dev_context *devc);
 SR_PRIV int openlb_start_acquisition(struct dev_context *devc);
 SR_PRIV int openlb_receive_data(int fd, int revents, void *cb_data);
+SR_PRIV int openlb_unitsize(const struct dev_context *devc);
 
 #endif


### PR DESCRIPTION
Currently, we're hard-coding the packet unitsize to 4, and sending all
data as a uint32_t. However, it seems that various output modules assume
that unitsize is the smallest byte encoding of the current number of
channels. This includes the srzip encoder, which cannot consume openlb
data, giving an error:

  Unexpected unit size, discarding logic data.

This change fixes the issue by adjusting the unitsize on generated
packets to the 1/2/3/4-byte size required for that number of channels.
We change the data buffer to a 'void *', and push 1/2/3/4-byte values as
appropriate.

This allows saving captures from a digilent discover device (which has 24
channels) to srzip.